### PR TITLE
Use statefully's new correlation IDs

### DIFF
--- a/lib/linearly/errors/broken_contract.rb
+++ b/lib/linearly/errors/broken_contract.rb
@@ -78,3 +78,4 @@ module Linearly
     end
   end
 end
+# rubocop:enable Metrics/LineLength

--- a/lib/linearly/step/static.rb
+++ b/lib/linearly/step/static.rb
@@ -98,8 +98,8 @@ module Linearly
       # @raise [NoMethodError]
       # @api private
       def method_missing(name, *args, &block)
-        allowed = (state.methods + self.class.inputs.keys).include?(name)
-        allowed ? state.send(name, *args, &block) : super
+        allowed = [:correlation_id] + state.methods + self.class.inputs.keys
+        allowed.include?(name) ? state.send(name, *args, &block) : super
       end
 
       # Companion to `method_missing`

--- a/lib/linearly/version.rb
+++ b/lib/linearly/version.rb
@@ -1,3 +1,3 @@
 module Linearly
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end

--- a/linearly.gemspec
+++ b/linearly.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.files      = Dir['lib/**/*.rb'] + Dir['spec/**/*.rb']
   spec.test_files = spec.files.grep(/^spec/)
 
-  spec.add_runtime_dependency 'statefully', '>= 0.1.5'
+  spec.add_runtime_dependency 'statefully', '>= 0.1.7'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'codecov'

--- a/spec/static_step.rb
+++ b/spec/static_step.rb
@@ -9,7 +9,7 @@ module Linearly
     end
 
     def call
-      succeed(string: (number + 1).to_s)
+      succeed(string: (number + 1).to_s + correlation_id)
     end
   end
 end

--- a/spec/step/static_spec.rb
+++ b/spec/step/static_spec.rb
@@ -37,7 +37,7 @@ module Linearly
           let(:args) { { number: 7 } }
 
           it { expect(result).to be_successful }
-          it { expect(result.string).to eq '8' }
+          it { expect(result.string).to start_with '8' }
         end
 
         context 'with incorrect input' do


### PR DESCRIPTION
We can always expect `correlation_id` to be available in `State` so `Step`s don't need to name it explicitly in their `inputs`.